### PR TITLE
feat: Split paragraph element

### DIFF
--- a/src/components/Text/Anchor.test.ts
+++ b/src/components/Text/Anchor.test.ts
@@ -1,0 +1,15 @@
+import { createAnchorElement } from "./Anchor";
+//todo: install testing library to actually check click
+describe('a tags', () => {
+    test('a link should click to a target if one is provided', () => {
+        const page =  document.body;
+        const link = createAnchorElement({
+            text: 'test',
+            url: 'https://www.google.com/',
+            target: 'blank'
+        });
+        page.appendChild(link);
+        expect(link.href).toBe('https://www.google.com/');
+        expect(link.target).toBe('_blank');
+    });
+});

--- a/src/components/Text/Anchor.ts
+++ b/src/components/Text/Anchor.ts
@@ -1,13 +1,7 @@
 import { addTextToElement } from "../../utils";
 
-type AnchorTargets = 'blank' | 'self' | 'parent' | 'top';
-
-interface LinkProps {
-  text: string; 
-  url: string;
-  target?: AnchorTargets;
-  noreferrer?: boolean;
-  noopener?: boolean;
+export interface LinkProps {
+  [key: string]: any;
 };
 
 /**
@@ -15,7 +9,15 @@ interface LinkProps {
  * @param data 
  * @returns an anchor element with attributes if needed
  */
-export const createAnchorElement = ({text, url, target, noreferrer, noopener}: LinkProps) => {
+export const createAnchorElement = (props: LinkProps) => {
+    const {
+      text,
+      url,
+      target,
+      noreferrer,
+      noopener
+    } = props;
+
     const link = document.createElement('a');
     //base settings
     link.setAttribute('href', url);
@@ -36,8 +38,6 @@ export const createAnchorElement = ({text, url, target, noreferrer, noopener}: L
     if(noopener) {
       link.setAttribute('rel', 'noopener');
     }
-
-    console.log(link)
 
     return link;
 };

--- a/src/components/Text/Anchor.ts
+++ b/src/components/Text/Anchor.ts
@@ -1,0 +1,45 @@
+import { addTextToElement } from "../../utils";
+
+interface AnchorProps {
+    text: string;
+    url: string;
+  }
+
+/**
+ * class that creates an anchor tag
+ */
+class AnchorElement extends HTMLElement {
+    static observedAttributes = ["url", "text"];
+    text: string;
+    url: string;s
+
+    constructor() {
+        super();
+        this.text = '';
+        this.url = '';
+    }
+   
+
+    connectedCallback() {
+        console.log('AnchorElement has mounted to the page', this as Node);
+        const link = document.createElement('a');
+        link.setAttribute('href', this.url);
+        addTextToElement(link, this.text);
+    }
+  }
+
+customElements.define('anchor-element', AnchorElement)
+
+/**
+ * 
+ * @param data 
+ * @returns a paragraph element and also functionality for paragraph elements with links
+ */
+export const createLinkElement = (data: { text: string, url: string}) => {
+    const link = document.createElement('anchor-element');
+    link.setAttribute('href', data.url);
+    addTextToElement(link, data.text);
+
+    return link;
+};
+

--- a/src/components/Text/Anchor.ts
+++ b/src/components/Text/Anchor.ts
@@ -1,44 +1,43 @@
 import { addTextToElement } from "../../utils";
 
-interface AnchorProps {
-    text: string;
-    url: string;
-  }
+type AnchorTargets = 'blank' | 'self' | 'parent' | 'top';
 
-/**
- * class that creates an anchor tag
- */
-class AnchorElement extends HTMLElement {
-    static observedAttributes = ["url", "text"];
-    text: string;
-    url: string;s
-
-    constructor() {
-        super();
-        this.text = '';
-        this.url = '';
-    }
-   
-
-    connectedCallback() {
-        console.log('AnchorElement has mounted to the page', this as Node);
-        const link = document.createElement('a');
-        link.setAttribute('href', this.url);
-        addTextToElement(link, this.text);
-    }
-  }
-
-customElements.define('anchor-element', AnchorElement)
+interface LinkProps {
+  text: string; 
+  url: string;
+  target?: AnchorTargets;
+  noreferrer?: boolean;
+  noopener?: boolean;
+};
 
 /**
  * 
  * @param data 
- * @returns a paragraph element and also functionality for paragraph elements with links
+ * @returns an anchor element with attributes if needed
  */
-export const createLinkElement = (data: { text: string, url: string}) => {
-    const link = document.createElement('anchor-element');
-    link.setAttribute('href', data.url);
-    addTextToElement(link, data.text);
+export const createAnchorElement = ({text, url, target, noreferrer, noopener}: LinkProps) => {
+    const link = document.createElement('a');
+    //base settings
+    link.setAttribute('href', url);
+    addTextToElement(link, text);
+
+    //optionalSettings
+    if (target) {
+      if(target === 'blank' && !noreferrer) {
+        console.log('If you are using target blank, we recommend adding noreferrer: true to the data object for security purposes')
+      }
+      link.setAttribute('target', `_${target}`)
+    }
+
+    if(noreferrer) {
+      link.setAttribute('rel', 'noreferrer');
+    }
+
+    if(noopener) {
+      link.setAttribute('rel', 'noopener');
+    }
+
+    console.log(link)
 
     return link;
 };

--- a/src/components/Text/Paragraph.ts
+++ b/src/components/Text/Paragraph.ts
@@ -1,4 +1,5 @@
 import { addTextToElement } from "../../utils";
+import { createAnchorElement, LinkProps } from "./Anchor";
 
 /**
  * class that creates a P tag
@@ -14,27 +15,47 @@ class Paragraph extends HTMLElement {
     }
 };
 
-export const splitParagraphElement = (data: object | object[] | string | string[]) => {
 
+/**
+ * 
+ * @param props 
+ * @returns a paragraph with links and text
+ */
+export const splitParagraphElement = (data: string | LinkProps) => {
+    const vals = Object.values(data);
+
+    const paragraph = document.createElement('paragraph-element');
+
+    vals.forEach(item => {
+        if (typeof item === 'string') {
+            paragraph.innerHTML += item;
+        }
+        paragraph.appendChild(createAnchorElement(item));
+    });
+
+    return paragraph;
 };
+
 
 /**
  * 
  * @param data 
  * @returns a paragraph element and also functionality for paragraph elements with links
  */
-export const createParagraphElement = (data: object | object[] | string | string[]) => {
+export const createParagraphElement = (data: string | LinkProps) => {
     const p = document.createElement('paragraph-element');
-    const dataArray = Array.isArray(data);
-    if (dataArray || typeof data === 'object') {
-        //todo:  create a split paragraph element with anchor links
-        console.log('this is an array or an object, use a different function');
-        return;
+
+    if(typeof data === 'string') {
+        addTextToElement(p, data);
     }
 
-    addTextToElement(p, data);
+    splitParagraphElement(data)
 
     return p;
 };
+
+
+
+
 
 customElements.define('paragraph-element', Paragraph)

--- a/src/components/Text/Paragraph.ts
+++ b/src/components/Text/Paragraph.ts
@@ -14,6 +14,15 @@ class Paragraph extends HTMLElement {
     }
 };
 
+export const splitParagraphElement = (data: object | object[] | string | string[]) => {
+
+};
+
+/**
+ * 
+ * @param data 
+ * @returns a paragraph element and also functionality for paragraph elements with links
+ */
 export const createParagraphElement = (data: object | object[] | string | string[]) => {
     const p = document.createElement('paragraph-element');
     const dataArray = Array.isArray(data);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@
 //Text
 export { createParagraphElement } from "./Text/Paragraph";
 export { createHeaderElement } from './Text/Header';
+export { createLinkElement } from './Text/Anchor';
 
 //elements
 export { createListComponent } from "./List/List";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,6 @@
 // each component and helpers
 //Text
-export { createParagraphElement } from "./Text/Paragraph";
+export { createParagraphElement, splitParagraphElement } from "./Text/Paragraph";
 export { createHeaderElement } from './Text/Header';
 export { createAnchorElement } from './Text/Anchor';
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,7 +2,7 @@
 //Text
 export { createParagraphElement } from "./Text/Paragraph";
 export { createHeaderElement } from './Text/Header';
-export { createLinkElement } from './Text/Anchor';
+export { createAnchorElement } from './Text/Anchor';
 
 //elements
 export { createListComponent } from "./List/List";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
     createListComponent,
     createParagraphElement,
     createHeaderElement,
-    createLinkElement
+    createAnchorElement
 } from "./components/index";
 
 window.addEventListener('DOMContentLoaded', () => {
@@ -21,9 +21,7 @@ window.addEventListener('DOMContentLoaded', () => {
     const p = createParagraphElement(paraData) as Node;
     const h1Left = createHeaderElement(data.home.lp, 'header1-element') as Node;
     const h1Right = createHeaderElement(data.home.ch, 'header1-element') as Node;
-    const link = document.createElement('anchor-element');
-    link.setAttribute('text', 'I AM LINK');
-    link.setAttribute('url', 'www.google.com')
+    const link = createAnchorElement({text: 'Hello World', url: 'https://www.google.com/', target: 'blank', noreferrer: true});
     
     
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 // this is the entry point for all functionality on the site
 import '@webcomponents/custom-elements';
 import data from './utils/textDictionary.json';
+import contactData from './utils/linkTextDictionary.json';
 import { stylesLoaded } from "./styles/index";
 import {
     createListComponent,
     createParagraphElement,
     createHeaderElement,
-    createAnchorElement
+    splitParagraphElement
 } from "./components/index";
 
 window.addEventListener('DOMContentLoaded', () => {
@@ -17,17 +18,19 @@ window.addEventListener('DOMContentLoaded', () => {
     const bodyElement = document.querySelector('body');
     const list = createListComponent(data);
 
-    const paraData = data.home.collabSlug;
-    const p = createParagraphElement(paraData) as Node;
+    const p = createParagraphElement(data.home.collabSlug) as Node;
     const h1Left = createHeaderElement(data.home.lp, 'header1-element') as Node;
     const h1Right = createHeaderElement(data.home.ch, 'header1-element') as Node;
-    const link = createAnchorElement({text: 'Hello World', url: 'https://www.google.com/', target: 'blank', noreferrer: true});
-    
+
+    const contact = splitParagraphElement(contactData.homepage) as Node;
+
+
     
 
-    bodyElement!.appendChild(list).appendChild(link);
+    bodyElement!.appendChild(list);
     bodyElement!.appendChild(h1Left).appendChild(h1Right);
     bodyElement!.appendChild(p);
+    bodyElement!.appendChild(contact);
 
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ import { stylesLoaded } from "./styles/index";
 import {
     createListComponent,
     createParagraphElement,
-    createHeaderElement
+    createHeaderElement,
+    createLinkElement
 } from "./components/index";
 
 window.addEventListener('DOMContentLoaded', () => {
@@ -20,8 +21,13 @@ window.addEventListener('DOMContentLoaded', () => {
     const p = createParagraphElement(paraData) as Node;
     const h1Left = createHeaderElement(data.home.lp, 'header1-element') as Node;
     const h1Right = createHeaderElement(data.home.ch, 'header1-element') as Node;
+    const link = document.createElement('anchor-element');
+    link.setAttribute('text', 'I AM LINK');
+    link.setAttribute('url', 'www.google.com')
+    
+    
 
-    bodyElement!.appendChild(list);
+    bodyElement!.appendChild(list).appendChild(link);
     bodyElement!.appendChild(h1Left).appendChild(h1Right);
     bodyElement!.appendChild(p);
 

--- a/src/utils/linkTextDictionary.json
+++ b/src/utils/linkTextDictionary.json
@@ -1,0 +1,23 @@
+{
+    "homepage": {
+        "intro": "My music recording studio is located at",
+        "locationLink":  {
+            "text": "40 West 27th Street", 
+            "url": "https://www.google.com/maps/place/40+W+27th+St,+New+York,+NY+10001/@40.7449338,-73.9925253,17z/data=!3m1!4b1!4m5!3m4!1s0x89c259a5c071704b:0xe4a883b4284f0cbd!8m2!3d40.7449298!4d-73.9903313", 
+            "target": "blank",
+            "noreferrer": true
+        },
+        "locationText": "in NYC, and I'm $50/hr.  Additonal Questions? Email me (Craig Levy)",
+        "emailLink": {
+            "text": "craig@littlepioneer.com", 
+            "url": "mailto:craig@littlepioneer.com?subject=Hey!", 
+            "target": "blank"
+        },
+        "phone": "or text/call",
+        "phoneLink": {
+            "text": "(917) 535-4529", 
+            "url": "tel:9175354529"
+        },
+        "closing":  ".  I look forward to hearing from you!"
+    }
+}


### PR DESCRIPTION
This PR adds a split paragraph element- that is to say one with text and links added.  It also adds a different data source.

It should be considered a first pass at a more robust element and currently has no tests.  

What needs to happen after this is that the types for this project should be teased out, so that they can be available generically to any component.  Then tests should be written and other use cases for this element tested, such as for text and links on other pages, rather  than one example on the homepage.