### PR TITLE
feat: Organize types on current components and refactor

### DIFF
--- a/src/components/List/List.ts
+++ b/src/components/List/List.ts
@@ -1,3 +1,4 @@
+import { ListElement } from "../../models";
 /**
  * class that creates the ul element
  */
@@ -12,11 +13,11 @@ export default class ListComponent extends HTMLElement {
     }
 };
 
-export const createListComponent = (data: {[key: string]: object | object[] | string}) => {
+export const createListComponent = ({data}: ListElement) => {
     const list = document.createElement('list-component');
 
-    const menuValues = Object.values(data.sections);
-    menuValues.forEach((item: string) => {
+    const menuValues = Object.values(data);
+    menuValues.forEach((item) => {
         const eachListItem = document.createElement('list-item-component')
         eachListItem.innerHTML = `<p>${item}</p>`;
         list.appendChild(eachListItem)

--- a/src/components/Text/Anchor.ts
+++ b/src/components/Text/Anchor.ts
@@ -1,3 +1,4 @@
+import { AnchorElement } from "../../models";
 import { addTextToElement } from "../../utils";
 
 export interface LinkProps {
@@ -9,15 +10,13 @@ export interface LinkProps {
  * @param data 
  * @returns an anchor element with attributes if needed
  */
-export const createAnchorElement = (props: LinkProps) => {
-    const {
-      text,
-      url,
-      target,
-      noreferrer,
-      noopener
-    } = props;
-
+export const createAnchorElement = ({
+  text,
+  url,
+  target,
+  noreferrer,
+  noopener
+}: AnchorElement) => {
     const link = document.createElement('a');
     //base settings
     link.setAttribute('href', url);

--- a/src/components/Text/Anchor.ts
+++ b/src/components/Text/Anchor.ts
@@ -1,14 +1,14 @@
 import { AnchorElement } from "../../models";
 import { addTextToElement } from "../../utils";
 
-export interface LinkProps {
-  [key: string]: any;
-};
-
 /**
  * 
- * @param data 
- * @returns an anchor element with attributes if needed
+ * @param {string} text 
+ * @param {string} url
+ * @param {string} target
+ * @param {boolean} noreferrer
+ * @param {boolean} noopener 
+ * @returns  an anchor element with optional target, no referrer and noopener props
  */
 export const createAnchorElement = ({
   text,

--- a/src/components/Text/Header.ts
+++ b/src/components/Text/Header.ts
@@ -1,22 +1,10 @@
+import { HeaderElement } from "../../models";
 import { addTextToElement } from "../../utils";
-/**
- * class that creates the base Header element
- */
-export class Header extends HTMLElement {
-    constructor() {
-        super();
-        console.log('base Header --->')
-    }
-
-    connectedCallback() {
-        console.log('Header has mounted to page');
-    }
-};
 
 /**
  * class that creates a H1 tag
  */
-export class Header1 extends Header {
+export class Header1 extends HTMLElement {
     constructor() {
         super();
         console.log('Header 1 --->')
@@ -30,7 +18,7 @@ export class Header1 extends Header {
 /**
  * class that creates a H2 tag
  */
-export class Header2 extends Header {
+export class Header2 extends HTMLElement {
     constructor() {
         super();
         console.log('Header 2 --->')
@@ -44,7 +32,7 @@ export class Header2 extends Header {
 /**
  * class that creates a H3 tag
  */
-export class Header3 extends Header {
+export class Header3 extends HTMLElement {
     constructor() {
         super();
         console.log('Header 3 --->')
@@ -58,7 +46,7 @@ export class Header3 extends Header {
 /**
  * class that creates a H4 tag
  */
-export class Header4 extends Header {
+export class Header4 extends HTMLElement {
     constructor() {
         super();
         console.log('Header 4 --->')
@@ -72,7 +60,7 @@ export class Header4 extends Header {
 /**
  * class that creates a H5 tag
  */
-export class Header5 extends Header {
+export class Header5 extends HTMLElement {
     constructor() {
         super();
         console.log('Header 5 --->')
@@ -86,7 +74,7 @@ export class Header5 extends Header {
 /**
  * class that creates a H6 tag
  */
-export class Header6 extends Header {
+export class Header6 extends HTMLElement {
     constructor() {
         super();
         console.log('Header 6 --->')
@@ -104,10 +92,10 @@ customElements.define('header4-element', Header4);
 customElements.define('header5-element', Header5);
 customElements.define('header6-element', Header6);
 
-export const createHeaderElement = (data: string , el: string) => {
-    const headerTag = document.createElement(`${el}`);
+export const createHeaderElement = (props: HeaderElement) => {
+    const headerTag = document.createElement(`${props.el}`);
 
-    addTextToElement(headerTag, data);
+    addTextToElement(headerTag, props.data);
 
     return headerTag;
 };

--- a/src/components/Text/Paragraph.ts
+++ b/src/components/Text/Paragraph.ts
@@ -1,5 +1,6 @@
+import { ParagraphElement } from "../../models";
 import { addTextToElement } from "../../utils";
-import { createAnchorElement, LinkProps } from "./Anchor";
+import { createAnchorElement } from "./Anchor";
 
 /**
  * class that creates a P tag
@@ -21,7 +22,7 @@ class Paragraph extends HTMLElement {
  * @param props 
  * @returns a paragraph with links and text
  */
-export const splitParagraphElement = (data: string | LinkProps) => {
+export const splitParagraphElement = (data: ParagraphElement) => {
     const vals = Object.values(data);
 
     const paragraph = document.createElement('paragraph-element');
@@ -42,7 +43,7 @@ export const splitParagraphElement = (data: string | LinkProps) => {
  * @param data 
  * @returns a paragraph element and also functionality for paragraph elements with links
  */
-export const createParagraphElement = (data: string | LinkProps) => {
+export const createParagraphElement = (data: ParagraphElement ) => {
     const p = document.createElement('paragraph-element');
 
     if(typeof data === 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,17 @@ window.addEventListener('DOMContentLoaded', () => {
     stylesLoaded();
 
     const bodyElement = document.querySelector('body');
-    const list = createListComponent(data);
+    const list = createListComponent(data.sections); 
 
     const p = createParagraphElement(data.home.collabSlug) as Node;
-    const h1Left = createHeaderElement(data.home.lp, 'header1-element') as Node;
-    const h1Right = createHeaderElement(data.home.ch, 'header1-element') as Node;
+    const h1Left = createHeaderElement({
+        data: data.home.lp,
+        el: 'header1-element'
+    }) as Node;
+    const h1Right = createHeaderElement({
+        data: data.home.ch, 
+        el: 'header1-element'
+    }) as Node;
 
     const contact = splitParagraphElement(contactData.homepage) as Node;
 

--- a/src/models/elements.ts
+++ b/src/models/elements.ts
@@ -1,0 +1,5 @@
+export interface ListComponent {
+    data: {
+        [key: string]: object | object[] | string
+    }
+};

--- a/src/models/elements.ts
+++ b/src/models/elements.ts
@@ -1,5 +1,3 @@
-export interface ListComponent {
-    data: {
-        [key: string]: object | object[] | string
-    }
+export interface ListElement {
+    [key: string]: object | object[] | string
 };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,5 +6,5 @@ export {
 } from './type';
 
 export {
-    ListComponent
+    ListElement
 } from './elements';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,0 +1,10 @@
+export { 
+    AnchorElement,
+    ParagraphElement,
+    HeaderElement,
+    TextElement 
+} from './type';
+
+export {
+    ListComponent
+} from './elements';

--- a/src/models/type.ts
+++ b/src/models/type.ts
@@ -1,0 +1,20 @@
+type TargetTypes = 'blank' | 'self' | 'parent' | 'top';
+
+export interface AnchorElement {
+    text: string;
+    url: string;
+    target?: TargetTypes;
+    noreferrer?: boolean;
+    noopener?: boolean;
+};
+
+export interface ParagraphElement {
+    data: string | AnchorElement;
+};
+
+export interface HeaderElement {
+    data: string;
+    el: string;
+};
+
+export type TextElement = AnchorElement | ParagraphElement | HeaderElement;

--- a/src/models/type.ts
+++ b/src/models/type.ts
@@ -8,8 +8,8 @@ export interface AnchorElement {
     noopener?: boolean;
 };
 
+
 export interface ParagraphElement {
-    data: string | AnchorElement;
 };
 
 export interface HeaderElement {
@@ -17,4 +17,5 @@ export interface HeaderElement {
     el: string;
 };
 
+// if multiple types may be necessary
 export type TextElement = AnchorElement | ParagraphElement | HeaderElement;


### PR DESCRIPTION
This PR adds a types folder, which organizes the current types on elements and also refactors some elements to make sure that they continue to render correctly.

Additionally, the header element has been refactored to remove the base header element, I currently don't see the value in this approach.